### PR TITLE
Inspect whole error array instead of just the first message

### DIFF
--- a/lib/sqewer/connection.rb
+++ b/lib/sqewer/connection.rb
@@ -126,7 +126,7 @@ class Sqewer::Connection
       resp = client.delete_message_batch(queue_url: @queue_url, entries: batch)
       failed = resp.failed
       if failed.any?
-        err = failed[0].message
+        err = failed.inspect
         raise "%d messages failed to delete (first error was %s)" % [failed.length, err]
       end
     end


### PR DESCRIPTION
It turns out that the returned error message from SQS is often
empty, so we inspect the entire array to hopefully get more
information on why it is failing.

See also issue 4 on nu_backend, this should give better errors in appsignal.