### PR TITLE
Permit local queues using SQLite

### DIFF
--- a/lib/sqewer/connection.rb
+++ b/lib/sqewer/connection.rb
@@ -25,9 +25,16 @@ class Sqewer::Connection
   end
 
   # Returns the default adapter, connected to the queue set via the `SQS_QUEUE_URL`
-  # environment variable.
+  # environment variable. Switches to SQLite-backed local queue if the SQS_QUEUE_URL
+  # is prefixed with 'sqlite3://'
   def self.default
-    new(ENV.fetch('SQS_QUEUE_URL'))
+    url_str = ENV.fetch('SQS_QUEUE_URL')
+    uri = URI(url_str)
+    if uri.scheme == 'sqlite3'
+      Sqewer::LocalConnection.new(uri.to_s)
+    else
+      new(uri.to_s)
+    end
   rescue KeyError => e
     raise "SQS_QUEUE_URL not set in the environment. This is the queue URL that the default that Sqewer uses"
   end

--- a/lib/sqewer/connection.rb
+++ b/lib/sqewer/connection.rb
@@ -36,7 +36,7 @@ class Sqewer::Connection
       new(uri.to_s)
     end
   rescue KeyError => e
-    raise "SQS_QUEUE_URL not set in the environment. This is the queue URL that the default that Sqewer uses"
+    raise "SQS_QUEUE_URL not set in the environment. This is the queue URL Sqewer uses by default."
   end
 
   # Initializes a new adapter, with access to the SQS queue at the given URL.

--- a/lib/sqewer/local_connection.rb
+++ b/lib/sqewer/local_connection.rb
@@ -1,0 +1,134 @@
+class Sqewer::LocalConnection < Sqewer::Connection
+  FAIL_AFTER_DELIVERIES = 10
+
+  def with_db(**k)
+    SQLite3::Database.open('sqewer-local-queue.sqlite3', **k) do |db|
+      db.busy_timeout = 5
+      return yield db
+    end
+  end
+
+  def with_readonly_db(&blk)
+    with_db(readonly: true, &blk)
+  end
+
+  def initialize(queue_url)
+    require 'sqlite3'
+    @queue_url = queue_url
+    with_db do |db|
+      db.execute("CREATE TABLE IF NOT EXISTS sqewer_messages_v1 (
+        id INTEGER PRIMARY KEY AUTOINCREMENT ,
+        queue_url VARCHAR NOT NULL,
+        receipt_handle VARCHAR NOT NULL,
+        deliver_after_epoch INTEGER,
+        times_delivered_so_far INTEGER DEFAULT 0,
+        last_delivery_at_epoch INTEGER,
+        visible BOOLEAN DEFAULT 't',
+        message_body TEXT)"
+      )
+      db.execute("CREATE INDEX IF NOT EXISTS index_sqewer_messages_v1_on_receipt_handle ON sqewer_messages_v1 (receipt_handle)")
+      db.execute("CREATE INDEX IF NOT EXISTS index_sqewer_messages_v1_on_queue_url ON sqewer_messages_v1 (queue_url)")
+    end
+  rescue LoadError => e
+    raise e, "You need the sqlite3 gem in your Gemfile to use LocalConnection. Add it to your Gemfile (`gem 'sqlite3'')"
+  end
+
+  # @return [Array<Message>] an array of Message objects 
+  def receive_messages
+    messages = load_receipt_handles_and_bodies
+    messages.map {|message| Message.new(message[0], message[1]) }
+  end
+
+  # @yield [#send_message] the object you can send messages through (will be flushed at method return)
+  # @return [void]
+  def send_multiple_messages
+    buffer = SendBuffer.new
+    yield(buffer)
+    messages = buffer.messages
+    persist_messages(messages)
+  end
+
+  # Deletes multiple messages after they all have been succesfully decoded and processed.
+  #
+  # @yield [#delete_message] an object you can delete an individual message through
+  # @return [void]
+  def delete_multiple_messages
+    buffer = DeleteBuffer.new
+    yield(buffer)
+    delete_persisted_messages(buffer.messages)
+  end
+
+  def truncate!
+    with_db do |db|
+      db.execute("DELETE FROM sqewer_messages_v1 WHERE queue_url = ?", @queue_url)
+    end
+  end
+
+  private
+
+  def delete_persisted_messages(messages)
+    ids_to_delete = messages.map{|m| m.fetch(:receipt_handle) }
+    with_db do |db|
+      db.execute("BEGIN")
+      ids_to_delete.each do |id|
+        db.execute("DELETE FROM sqewer_messages_v1 WHERE receipt_handle = ?", id)
+      end
+      db.execute("COMMIT")
+    end
+  end
+
+  def load_receipt_handles_and_bodies
+    t = Time.now.to_i
+
+    # First make messages that were previously marked invisible but not deleted visible again
+    with_db do |db|
+      db.execute("BEGIN")
+      # Make messages visible that have to be redelivered
+      db.execute("UPDATE sqewer_messages_v1
+        SET visible = 't' 
+        WHERE queue_url = ? AND visible = 'f' AND last_delivery_at_epoch < ?", @queue_url.to_s, t - 60)
+      # Remove hopeless messages
+      db.execute("DELETE FROM sqewer_messages_v1
+        WHERE queue_url = ? AND times_delivered_so_far > ?", @queue_url.to_s, FAIL_AFTER_DELIVERIES)
+      db.execute("COMMIT")
+    end
+
+    rows = with_readonly_db do |db|
+      db.execute("SELECT id, receipt_handle, message_body FROM sqewer_messages_v1
+        WHERE queue_url = ? AND visible = 't' AND deliver_after_epoch <= ? AND last_delivery_at_epoch <= ?",
+        @queue_url.to_s, t, t)
+    end
+    
+    with_db do |db|
+      db.execute("BEGIN")
+      rows.map do |(id, *_)|
+        db.execute("UPDATE sqewer_messages_v1
+          SET visible = 'f', times_delivered_so_far = times_delivered_so_far + 1, last_delivery_at_epoch = ?
+          WHERE id = ?", t, id)
+      end
+      db.execute("COMMIT")
+    end
+
+    rows.map do |(_, *receipt_handle_and_body)|
+      receipt_handle_and_body
+    end
+  end
+
+  def persist_messages(messages)
+    bodies_and_deliver_afters = messages.map do |msg|
+      [msg.fetch(:message_body), Time.now.to_i + msg.fetch(:delay_seconds, 0)]
+    end
+    fake_last_delivery_t = Time.now.to_i
+    
+    with_db do |db|
+      db.execute("BEGIN")
+      bodies_and_deliver_afters.map do |body, deliver_after_epoch|
+        db.execute("INSERT INTO sqewer_messages_v1
+          (queue_url, receipt_handle, message_body, deliver_after_epoch, last_delivery_at_epoch)
+          VALUES(?, ?, ?, ?, ?)",
+          @queue_url.to_s, SecureRandom.uuid, body, deliver_after_epoch, fake_last_delivery_t)
+      end
+      db.execute("COMMIT")
+    end
+  end
+end

--- a/lib/sqewer/worker.rb
+++ b/lib/sqewer/worker.rb
@@ -110,7 +110,7 @@ class Sqewer::Worker
               @logger.debug { "[worker] Received and buffered %d messages" % messages.length } if messages.any?
             else
               @logger.debug { "[worker] No messages received" }
-              Thread.pass
+              sleep SLEEP_SECONDS_ON_EMPTY_QUEUE
             end
           else
             @logger.debug { "[worker] Cache is full (%d items), postponing receive" % @execution_queue.length }

--- a/spec/sqewer/connection_spec.rb
+++ b/spec/sqewer/connection_spec.rb
@@ -3,7 +3,8 @@ require_relative '../spec_helper'
 describe Sqewer::Connection do
   describe '.default' do
     it 'returns a new LocalConnection if SQS_QUEUE_URL references sqlite:// as proto' do
-      expect(ENV).to receive(:fetch).with('SQS_QUEUE_URL').and_return('sqlite3://my-fake-q')
+      tf = Tempfile.new('sqlite-db')
+      expect(ENV).to receive(:fetch).with('SQS_QUEUE_URL').and_return('sqlite3://' + tf.path)
       default = described_class.default
       expect(default).to be_kind_of(Sqewer::LocalConnection)
     end

--- a/spec/sqewer/connection_spec.rb
+++ b/spec/sqewer/connection_spec.rb
@@ -2,6 +2,12 @@ require_relative '../spec_helper'
 
 describe Sqewer::Connection do
   describe '.default' do
+    it 'returns a new LocalConnection if SQS_QUEUE_URL references sqlite:// as proto' do
+      expect(ENV).to receive(:fetch).with('SQS_QUEUE_URL').and_return('sqlite3://my-fake-q')
+      default = described_class.default
+      expect(default).to be_kind_of(Sqewer::LocalConnection)
+    end
+
     it 'returns a new Connection with the SQS queue location picked from SQS_QUEUE_URL envvar' do
       expect(ENV).to receive(:fetch).with('SQS_QUEUE_URL').and_return('https://aws-fake-queue.com')
       default = described_class.default

--- a/spec/sqewer/local_connection_spec.rb
+++ b/spec/sqewer/local_connection_spec.rb
@@ -25,20 +25,4 @@ describe Sqewer::LocalConnection do
     messages = conn.receive_messages
     expect(messages).to be_empty
   end
-
-  describe '#send_multiple_messages' do
-    it 'sends 100 messages' do
-      conn = described_class.new('https://fake-queue.com')
-      conn.send_multiple_messages do | b |
-        102.times { b.send_message("Hello - #{SecureRandom.uuid}") }
-      end
-    end
-
-    it 'retries the message if it fails with a random AWS error' do
-      conn = described_class.new('https://fake-queue.com')
-      conn.send_multiple_messages do | b |
-        b.send_message("Hello - #{SecureRandom.uuid}")
-      end
-    end
-  end
 end

--- a/spec/sqewer/local_connection_spec.rb
+++ b/spec/sqewer/local_connection_spec.rb
@@ -1,7 +1,14 @@
 require_relative '../spec_helper'
 
 describe Sqewer::LocalConnection do
-  let(:temp_db_uri) { 'sqlite3:/%s/sqewer.sqlite3' % Dir.pwd }
+  around :each do |example|
+    Dir.mktmpdir do |tmpdir_path|
+      @tempdir_path = tmpdir_path
+      example.run
+    end
+  end
+
+  let(:temp_db_uri) { 'sqlite3:/%s/sqewer.sqlite3' % @tempdir_path }
 
   it 'honors the given database path and queue name' do
     Dir.mktmpdir do |tempdir_path|

--- a/spec/sqewer/local_connection_spec.rb
+++ b/spec/sqewer/local_connection_spec.rb
@@ -1,0 +1,44 @@
+require_relative '../spec_helper'
+
+describe Sqewer::LocalConnection do
+
+  it 'handles a full send/receive/delete cycle' do
+    conn = described_class.new('https://fake-queue.com')
+    conn.truncate!
+    conn.send_multiple_messages do | b |
+      4.times { b.send_message("Hello - #{SecureRandom.uuid}") }
+    end
+    
+    messages = conn.receive_messages
+    expect(messages.length).to eq(4)
+
+    # Now the messages have become invisible
+    messages = conn.receive_messages
+    expect(messages.length).to eq(0)
+
+    conn.delete_multiple_messages do | b |
+      messages.each do |m|
+        b.delete_message(m.id)
+      end
+    end
+
+    messages = conn.receive_messages
+    expect(messages).to be_empty
+  end
+
+  describe '#send_multiple_messages' do
+    it 'sends 100 messages' do
+      conn = described_class.new('https://fake-queue.com')
+      conn.send_multiple_messages do | b |
+        102.times { b.send_message("Hello - #{SecureRandom.uuid}") }
+      end
+    end
+
+    it 'retries the message if it fails with a random AWS error' do
+      conn = described_class.new('https://fake-queue.com')
+      conn.send_multiple_messages do | b |
+        b.send_message("Hello - #{SecureRandom.uuid}")
+      end
+    end
+  end
+end

--- a/spec/sqewer/local_connection_spec.rb
+++ b/spec/sqewer/local_connection_spec.rb
@@ -1,9 +1,25 @@
 require_relative '../spec_helper'
 
 describe Sqewer::LocalConnection do
+  let(:temp_db_uri) { 'sqlite3:/%s/sqewer.sqlite3' % Dir.pwd }
+
+  it 'honors the given database path and queue name' do
+    Dir.mktmpdir do |tempdir_path|
+      db_path = tempdir_path + '/test.sqlite3'
+      qname = 'foobarbaz'
+      uri_in_tempdir = 'sqlite3:/%s?queue=%s' % [db_path, qname]
+
+      conn = described_class.new(uri_in_tempdir)
+      conn.send_message("Hello!")
+
+      db = SQLite3::Database.open(tempdir_path + '/test.sqlite3')
+      expect(db.get_first_value('SELECT COUNT(id) FROM sqewer_messages_v2')).to eq(1)
+      expect(db.get_first_value('SELECT queue_name FROM sqewer_messages_v2')).to eq('foobarbaz')
+    end
+  end
 
   it 'handles a full send/receive/delete cycle' do
-    conn = described_class.new('https://fake-queue.com')
+    conn = described_class.new(temp_db_uri)
     conn.truncate!
     conn.send_multiple_messages do | b |
       4.times { b.send_message("Hello - #{SecureRandom.uuid}") }
@@ -24,5 +40,32 @@ describe Sqewer::LocalConnection do
 
     messages = conn.receive_messages
     expect(messages).to be_empty
+  end
+
+  it 'is able to send from one process and receive from another' do
+    conn = described_class.new(temp_db_uri)
+    conn.truncate!
+
+    producer_pid = fork do
+      sleep 1.0
+      conn.send_multiple_messages do | b |
+        b.send_message("Hello from a producer co-process!")
+      end
+    end
+
+    consumer_pid = fork do
+      sleep 1.5
+      msgs = conn.receive_messages
+      exit(0) if msgs.length == 2
+      raise "This is not what we expected. Received messages were #{msgs.inspect} but we really need 2 message to be there"
+    end
+
+    conn.send_multiple_messages do | b |
+      b.send_message("Hello from parent!")
+    end
+
+    Process.wait(producer_pid)
+    Process.wait(consumer_pid)
+    expect($?.exitstatus).to eq(0)
   end
 end

--- a/sqewer.gemspec
+++ b/sqewer.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency 'aws-sdk', '~> 2'
+  spec.add_runtime_dependency 'rack'
   spec.add_runtime_dependency 'very_tiny_state_machine'
   spec.add_runtime_dependency 'ks'
   spec.add_runtime_dependency 'retriable'


### PR DESCRIPTION
Vairous SQS emulators are in various stages of readiness.
For example, fake_sqs is processor hungry, and awsgo does not
support SendMessageBatch. Because we have an abstraction layer on
top of the actual message sends it's time to leverage it to permit
running _without_ any SQS emulators either