### PR TITLE
 Expose enqueue and enqueue_at both ways

### DIFF
--- a/lib/sqewer/extensions/active_job_adapter.rb
+++ b/lib/sqewer/extensions/active_job_adapter.rb
@@ -69,18 +69,34 @@ module ActiveJob
         
       end
 
-      def enqueue(active_job) #:nodoc:
+      def self.enqueue(active_job) #:nodoc:
         wrapped_job = Performable.from_active_job(active_job)
 
         Sqewer.submit!(wrapped_job)
       end
 
-      def enqueue_at(active_job, timestamp) #:nodoc:
+      def self.enqueue_at(active_job, timestamp) #:nodoc:
         wrapped_job = Performable.from_active_job(active_job)
 
         delta_t = (timestamp - Time.now.to_i).to_i
 
         Sqewer.submit!(wrapped_job, delay_seconds: delta_t)
+      end
+
+      # ActiveJob in Rails 4 resolves the symbol value you give it
+      # and then tries to call enqueue_* methods directly on what
+      # got resolved. In Rails 5, first Rails will call .new on
+      # what it resolved from the symbol and _then_ call enqueue
+      # and enqueue_at on that what has gotten resolved. This means
+      # that we have to expose these methods _both_ as class methods
+      # and as instance methods.
+      # This can be removed when we stop supporting Rails 4.
+      def enqueue_at(*args)
+        self.class.enqueue_at(*args)
+      end
+      
+      def enqueue(*args)
+        self.class.enqueue(*args)
       end
     end
   end

--- a/spec/sqewer/active_job_spec.rb
+++ b/spec/sqewer/active_job_spec.rb
@@ -74,7 +74,7 @@ end
 describe ActiveJob::QueueAdapters::SqewerAdapter, :sqs => true do
 
   before :each do
-    ActiveJob::Base.queue_adapter = ActiveJob::QueueAdapters::SqewerAdapter.new
+    ActiveJob::Base.queue_adapter = :sqewer
 
     test_seed_name = SecureRandom.hex(4)
     ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: '%s/workdb.sqlite3' % Dir.pwd)


### PR DESCRIPTION
ActiveJob in Rails 4 resolves the symbol value you give it
and then tries to call enqueue_* methods directly on what
got resolved. In Rails 5, first Rails will call .new on
what it resolved from the symbol and _then_ call enqueue
and enqueue_at on that what has gotten resolved. This means
that we have to expose these methods _both_ as class methods
and as instance methods.

This can be removed when we stop supporting Rails 4.