### PR TITLE
Set queue_start in Appsignal to the SendTimestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,8 +248,8 @@ You can wrap job processing in middleware. A full-featured middleware class look
 
     class MyWrapper
       # Surrounds the job instantiation from the string coming from SQS.
-      def around_deserialization(serializer, msg_id, msg_payload)
-        # msg_id is the receipt handle, msg_payload is the message body string
+      def around_deserialization(serializer, msg_id, msg_payload, msg_attributes)
+        # msg_id is the receipt handle, msg_payload is the message body string, msg_attributes are the message's attributes
         yield
       end
       

--- a/lib/sqewer/connection.rb
+++ b/lib/sqewer/connection.rb
@@ -14,7 +14,7 @@ class Sqewer::Connection
   NotOurFaultAwsError = Class.new(StandardError)
 
   # A wrapper for most important properties of the received message
-  class Message < Struct.new(:receipt_handle, :body)
+  class Message < Struct.new(:receipt_handle, :body, :attributes)
     def inspect
       body.inspect
     end
@@ -57,7 +57,7 @@ class Sqewer::Connection
     Retriable.retriable on: Seahorse::Client::NetworkingError, tries: MAX_RANDOM_RECEIVE_FAILURES do
       response = client.receive_message(queue_url: @queue_url,
         wait_time_seconds: DEFAULT_TIMEOUT_SECONDS, max_number_of_messages: BATCH_RECEIVE_SIZE)
-      response.messages.map {|message| Message.new(message.receipt_handle, message.body) }
+      response.messages.map {|message| Message.new(message.receipt_handle, message.body, message.attributes) }
     end
   end
 

--- a/lib/sqewer/extensions/appsignal_wrapper.rb
+++ b/lib/sqewer/extensions/appsignal_wrapper.rb
@@ -22,7 +22,7 @@ module Sqewer
         def env; {params: self.params}; end
       end
 
-      def around_deserialization(serializer, msg_id, msg_payload)
+      def around_deserialization(serializer, msg_id, msg_payload, msg_attributes)
         return yield unless Appsignal.active?
 
         # This creates a transaction, but also sets it as the Appsignal.current_transaction
@@ -35,7 +35,9 @@ module Sqewer
 
         transaction.set_action('%s#%s' % [serializer.class, 'unserialize'])
         transaction.request.params = {:sqs_message_body => msg_payload.to_s}
-        transaction.set_http_or_background_queue_start
+        if msg_attributes.key?('SentTimestamp')
+          transaction.set_queue_start = Time.at(msg_attributes['SentTimestamp'].to_i / 1000)
+        end
 
         job_unserialized = yield
 

--- a/lib/sqewer/extensions/appsignal_wrapper.rb
+++ b/lib/sqewer/extensions/appsignal_wrapper.rb
@@ -36,7 +36,7 @@ module Sqewer
         transaction.set_action('%s#%s' % [serializer.class, 'unserialize'])
         transaction.request.params = {:sqs_message_body => msg_payload.to_s}
         if msg_attributes.key?('SentTimestamp')
-          transaction.set_queue_start = Time.at(msg_attributes['SentTimestamp'].to_i / 1000)
+          transaction.set_queue_start = Time.at(msg_attributes['SentTimestamp'].to_i / 1000.0)
         end
 
         job_unserialized = yield

--- a/lib/sqewer/middleware_stack.rb
+++ b/lib/sqewer/middleware_stack.rb
@@ -33,12 +33,12 @@ class Sqewer::MiddlewareStack
     }.call
   end
 
-  def around_deserialization(serializer, message_id, message_body, &inner_block)
+  def around_deserialization(serializer, message_id, message_body, message_attributes, &inner_block)
     return yield if @handlers.empty?
 
     responders = @handlers.select{|e| e.respond_to?(:around_deserialization) }
     responders.reverse.inject(inner_block) {|outer_block, middleware_object|
-      ->{ middleware_object.public_send(:around_deserialization, serializer, message_id, message_body, &outer_block) }
+      ->{ middleware_object.public_send(:around_deserialization, serializer, message_id, message_body, message_attributes, &outer_block) }
     }.call
   end
 end

--- a/lib/sqewer/worker.rb
+++ b/lib/sqewer/worker.rb
@@ -204,7 +204,7 @@ class Sqewer::Worker
     box = Sqewer::ConnectionMessagebox.new(connection)
     return box.delete_message(message.receipt_handle) unless message.has_body?
 
-    job = middleware_stack.around_deserialization(serializer, message.receipt_handle, message.body) do
+    job = middleware_stack.around_deserialization(serializer, message.receipt_handle, message.body, message.attributes) do
       serializer.unserialize(message.body)
     end
     return unless job
@@ -243,7 +243,7 @@ class Sqewer::Worker
     # thread-safe - or at least not it's HTTP client part).
     box = Sqewer::ConnectionMessagebox.new(connection)
 
-    job = middleware_stack.around_deserialization(serializer, message.receipt_handle, message.body) do
+    job = middleware_stack.around_deserialization(serializer, message.receipt_handle, message.body, message.attributes) do
       serializer.unserialize(message.body)
     end
     return unless job

--- a/spec/sqewer/connection_spec.rb
+++ b/spec/sqewer/connection_spec.rb
@@ -164,7 +164,7 @@ describe Sqewer::Connection do
       expect(Aws::SQS::Client).to receive(:new) { fake_sqs_client }
       
       fake_messages = (1..5).map {
-        double(receipt_handle: SecureRandom.hex(4), body: SecureRandom.random_bytes(128))
+        double(receipt_handle: SecureRandom.hex(4), body: SecureRandom.random_bytes(128), attributes: { 'attr' => 'val' })
       }
       fake_response = double(messages: fake_messages)
       

--- a/spec/sqewer/middleware_stack_spec.rb
+++ b/spec/sqewer/middleware_stack_spec.rb
@@ -9,7 +9,7 @@ describe Sqewer::MiddlewareStack do
   describe '#around_deserialization' do
     it 'works without any handlers added' do
       stack = described_class.new
-      prepare_result = stack.around_deserialization(nil, 'msg-123', '{"body":"some text"}') { :prepared }
+      prepare_result = stack.around_deserialization(nil, 'msg-123', '{"body":"some text"}', { 'attr' => 'val' }) { :prepared }
       expect(prepare_result).to eq(:prepared)
     end
     
@@ -26,14 +26,14 @@ describe Sqewer::MiddlewareStack do
       stack << double('Object that does not handle around_deserialization')
       stack << handler
       stack << handler
-      result = stack.around_deserialization(nil, 'msg-123', '{"body":"some text"}') { :foo }
+      result = stack.around_deserialization(nil, 'msg-123', '{"body":"some text"}', { 'attr' => 'val' }) { :foo }
       expect(result).to eq(:foo)
       expect(called).not_to be_empty
       
       expect(called).to eq([
-          [nil, "msg-123", "{\"body\":\"some text\"}"],
-          [nil, "msg-123", "{\"body\":\"some text\"}"],
-          [nil, "msg-123", "{\"body\":\"some text\"}"]]
+          [nil, "msg-123", "{\"body\":\"some text\"}", { 'attr' => 'val' }],
+          [nil, "msg-123", "{\"body\":\"some text\"}", { 'attr' => 'val' }],
+          [nil, "msg-123", "{\"body\":\"some text\"}", { 'attr' => 'val' }]]
       )
     end
   end


### PR DESCRIPTION
This PR sets `queue_start` in Appsignal in order to track queue times. For this, message attributes need to be passed to `MiddlewareStack#around_deserialization`

Linked to https://github.com/WeTransfer/pegacorn-worker/issues/42