### PR TITLE
Use millis since epoch when calling set_queue_start

### DIFF
--- a/lib/sqewer/extensions/appsignal_wrapper.rb
+++ b/lib/sqewer/extensions/appsignal_wrapper.rb
@@ -36,7 +36,7 @@ module Sqewer
         transaction.set_action('%s#%s' % [serializer.class, 'unserialize'])
         transaction.request.params = {:sqs_message_body => msg_payload.to_s}
         if msg_attributes.key?('SentTimestamp')
-          transaction.set_queue_start = Time.at(msg_attributes['SentTimestamp'].to_i / 1000.0)
+          transaction.set_queue_start = msg_attributes['SentTimestamp'].to_i
         end
 
         job_unserialized = yield


### PR DESCRIPTION
This didn't previously work, because we were calling `transaction.set_queue_start` with a `Time` object, whereas this is a lower-level method that only accepts integers.

[`SentTimestamp`](https://docs.aws.amazon.com/sdkforruby/api/Aws/SQS/Client.html#receive_message-instance_method) from an SQS message returns millis since epoch. Appsignal [converts](https://github.com/appsignal/appsignal-ruby/blob/450959d3ad2180c22fe7343760dbb61b0bf2bdef/lib/appsignal/transaction.rb#L346) times to integers, and [dispatches](https://github.com/appsignal/appsignal-ruby/blob/57b3b7f8a024226c89fb9788a8772047c681ab8f/ext/appsignal_extension.c#L236) them to the C library in the same way. So, this PR fixes this by providing the actual millis since epoch (as provided by SQS), as an integer.