### PR TITLE
Refuse oversize messages / use middleware around flushes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 6.4.0
 - Raise an exception in submit! if the job serializes to a message that is
   above the native SQS limit for message size.
+- Ensure SendMessageBatch is only performed for batches totaling 256KB of message size or less.
 - Insert Sqewer::Error between StandardError and our custom errors for easier rescuing
 
 ### 6.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 6.4.0
+- Raise an exception in submit! if the job serializes to a message that is
+  above the native SQS limit for message size.
+- Insert Sqewer::Error between StandardError and our custom errors for easier rescuing
+
 ### 6.3.0
 - Add support for Ruby 2.7
 

--- a/lib/sqewer.rb
+++ b/lib/sqewer.rb
@@ -1,5 +1,8 @@
 # The enclosing module for the library
 module Sqewer
+  class Error < StandardError
+  end
+
   # Eager-load everything except extensions. Sort to ensure
   # the files load in the same order on all platforms.
   Dir.glob(__dir__ + '/**/*.rb').sort.each do |path|
@@ -23,7 +26,7 @@ module Sqewer
   def self.submit!(*jobs, **options)
     Sqewer::Submitter.default.submit!(*jobs, **options)
   end
-  
+
   # If we are within Rails, load the railtie
   require_relative 'sqewer/extensions/railtie' if defined?(Rails)
 

--- a/lib/sqewer/connection.rb
+++ b/lib/sqewer/connection.rb
@@ -91,6 +91,58 @@ class Sqewer::Connection
       m[:delay_seconds] = kwargs_for_send[:delay_seconds] if kwargs_for_send[:delay_seconds]
       messages << m
     end
+
+    # each_batch here also needs to ensure that the sum of payload lengths does not exceed 256kb
+    def each_batch
+      regrouped = pack_into_batches(messages, weight_limit: 256 * 1024, batch_length_limit: 10) do |message|
+        message.fetch(:message_body).bytesize
+      end
+      regrouped.each { |b| yield(b) }
+    end
+
+    # Optimizes a large list of items into batches of 10 items
+    # or less and with the sum of item lengths being below 256KB
+    # The block given to the method should return the weight of the given item
+    def pack_into_batches(items, weight_limit:, batch_length_limit:)
+      batches = []
+      current_batch = []
+      current_batch_weight = 0
+
+      # Sort the items by their weight (length of the body).
+      sorted_items = items.sort_by { |item| yield(item) }
+
+      # and then take 1 item from the list and append it to the batch if it fits.
+      # If it doesn't fit, no item after it will fit into this batch either (!)
+      # which is how we can optimize
+      sorted_items.each_with_index do |item|
+        weight_of_this_item = yield(item)
+
+        # First protect from invalid input
+        if weight_of_this_item > weight_limit
+          raise "#{item.inspect} was larger than the permissible limit"
+        # The first limit is on the item count per batch -
+        # if we are limited on that the batch needs to be closed
+        elsif current_batch.length == batch_length_limit
+          batches << current_batch
+          current_batch = []
+          current_batch_weight = 0
+        # If placing this item in the batch would make the batch overweight
+        # we need to close the batch, because all the items which come after
+        # this one will be same size or larger. This is the key part of the optimization.
+        elsif (current_batch_weight + weight_of_this_item) > weight_limit
+          batches << current_batch
+          current_batch = []
+          current_batch_weight = 0
+        end
+
+        # and then append the item to the current batch
+        current_batch_weight += weight_of_this_item
+        current_batch << item
+      end
+      batches << current_batch unless current_batch.empty?
+
+      batches
+    end
   end
 
   # Saves the receipt handles to batch-delete from the SQS queue

--- a/lib/sqewer/connection.rb
+++ b/lib/sqewer/connection.rb
@@ -11,7 +11,7 @@ class Sqewer::Connection
   MAX_RANDOM_FAILURES_PER_CALL = 10
   MAX_RANDOM_RECEIVE_FAILURES = 100 # sure to hit the max_elapsed_time of 900 seconds
 
-  NotOurFaultAwsError = Class.new(StandardError)
+  NotOurFaultAwsError = Class.new(Sqewer::Error)
 
   # A wrapper for most important properties of the received message
   class Message < Struct.new(:receipt_handle, :body, :attributes)

--- a/lib/sqewer/extensions/appsignal_wrapper.rb
+++ b/lib/sqewer/extensions/appsignal_wrapper.rb
@@ -4,7 +4,6 @@ module Sqewer
     # to Appsignal and to monitor performance. Will only activate
     # if the Appsignal gem is loaded within the current process and active.
     class AppsignalWrapper
-
       def self.new
         if defined?(Appsignal)
           super

--- a/lib/sqewer/middleware_stack.rb
+++ b/lib/sqewer/middleware_stack.rb
@@ -41,4 +41,15 @@ class Sqewer::MiddlewareStack
       ->{ middleware_object.public_send(:around_deserialization, serializer, message_id, message_body, message_attributes, &outer_block) }
     }.call
   end
+
+  def around_messagebox_cleanup(message_box, &inner_block)
+    return yield if @handlers.empty?
+
+    responders = @handlers.select{|e| e.respond_to?(:around_messagebox_cleanup) }
+    responders.reverse.inject(inner_block) {|outer_block, middleware_object|
+      ->{
+        middleware_object.public_send(:around_execution, message_box, &outer_block)
+      }
+    }.call
+  end
 end

--- a/lib/sqewer/middleware_stack.rb
+++ b/lib/sqewer/middleware_stack.rb
@@ -41,15 +41,4 @@ class Sqewer::MiddlewareStack
       ->{ middleware_object.public_send(:around_deserialization, serializer, message_id, message_body, message_attributes, &outer_block) }
     }.call
   end
-
-  def around_messagebox_cleanup(message_box, &inner_block)
-    return yield if @handlers.empty?
-
-    responders = @handlers.select{|e| e.respond_to?(:around_messagebox_cleanup) }
-    responders.reverse.inject(inner_block) {|outer_block, middleware_object|
-      ->{
-        middleware_object.public_send(:around_execution, message_box, &outer_block)
-      }
-    }.call
-  end
 end

--- a/lib/sqewer/simple_job.rb
+++ b/lib/sqewer/simple_job.rb
@@ -5,8 +5,8 @@
 # * to_h() will produce a symbolized Hash with all the properties defined using attr_accessor, and the job_class_name
 # * inspect() will provide a sensible default string representation for logging
 module Sqewer::SimpleJob
-  UnknownJobAttribute = Class.new(StandardError)
-  MissingAttribute = Class.new(StandardError)
+  UnknownJobAttribute = Class.new(Sqewer::Error)
+  MissingAttribute = Class.new(Sqewer::Error)
 
   EQ_END = /(\w+)(\=)$/
 

--- a/lib/sqewer/submitter.rb
+++ b/lib/sqewer/submitter.rb
@@ -3,7 +3,10 @@
 # and the serializer (something that responds to `#serialize`) to
 # convert the job into the string that will be put in the queue.
 class Sqewer::Submitter < Struct.new(:connection, :serializer)
+  MAX_PERMITTED_MESSAGE_SIZE_BYTES = 256 * 1024
+
   NotSqewerJob = Class.new(Sqewer::Error)
+  MessageTooLarge = Class.new(Sqewer::Error)
 
   # Returns a default Submitter, configured with the default connection
   # and the default serializer.
@@ -12,7 +15,7 @@ class Sqewer::Submitter < Struct.new(:connection, :serializer)
   end
 
   def submit!(job, **kwargs_for_send)
-    raise NotSqewerJob.new("Submitted object is not a valid job: #{job.inspect}") unless job.respond_to?(:run)
+    validate_job_responds_to_run!(job)
     message_body = if delay_by_seconds = kwargs_for_send[:delay_seconds]
       clamped_delay = clamp_delay(delay_by_seconds)
       kwargs_for_send[:delay_seconds] = clamped_delay
@@ -21,10 +24,25 @@ class Sqewer::Submitter < Struct.new(:connection, :serializer)
     else
       serializer.serialize(job)
     end
+    validate_message_for_size!(message_body, job)
+
     connection.send_message(message_body, **kwargs_for_send)
   end
 
   private
+
+  def validate_job_responds_to_run!(job)
+    return if job.respond_to?(:run)
+    error_message = "Submitted object is not a valid job (does not respond to #run): #{job.inspect}"
+    raise NotSqewerJob.new(error_message)
+  end
+
+  def validate_message_for_size!(message_body, job)
+    actual_bytesize = message_body.bytesize
+    return if actual_bytesize <= MAX_PERMITTED_MESSAGE_SIZE_BYTES
+    error_message = "Job #{job.class.inspect} serialized to a message which was too large (#{actual_bytesize} bytes)"
+    raise MessageTooLarge.new(error_message)
+  end
 
   def clamp_delay(delay)
     [1, 899, delay].sort[1]

--- a/lib/sqewer/submitter.rb
+++ b/lib/sqewer/submitter.rb
@@ -40,7 +40,7 @@ class Sqewer::Submitter < Struct.new(:connection, :serializer)
   def validate_message_for_size!(message_body, job)
     actual_bytesize = message_body.bytesize
     return if actual_bytesize <= MAX_PERMITTED_MESSAGE_SIZE_BYTES
-    error_message = "Job #{job.class.inspect} serialized to a message which was too large (#{actual_bytesize} bytes)"
+    error_message = "Job #{job.inspect} serialized to a message which was too large (#{actual_bytesize} bytes)"
     raise MessageTooLarge.new(error_message)
   end
 

--- a/lib/sqewer/submitter.rb
+++ b/lib/sqewer/submitter.rb
@@ -3,7 +3,7 @@
 # and the serializer (something that responds to `#serialize`) to
 # convert the job into the string that will be put in the queue.
 class Sqewer::Submitter < Struct.new(:connection, :serializer)
-  NotSqewerJob = Class.new(StandardError)
+  NotSqewerJob = Class.new(Sqewer::Error)
 
   # Returns a default Submitter, configured with the default connection
   # and the default serializer.
@@ -23,9 +23,9 @@ class Sqewer::Submitter < Struct.new(:connection, :serializer)
     end
     connection.send_message(message_body, **kwargs_for_send)
   end
-  
+
   private
-  
+
   def clamp_delay(delay)
     [1, 899, delay].sort[1]
   end

--- a/lib/sqewer/worker.rb
+++ b/lib/sqewer/worker.rb
@@ -48,7 +48,7 @@ class Sqewer::Worker
   #
   # @param connection[Sqewer::Connection] the object that handles polling and submitting
   # @param serializer[#serialize, #unserialize] the serializer/unserializer for the jobs
-  # @param execution_context_class[Class] the class for the execution context (will be instantiated by 
+  # @param execution_context_class[Class] the class for the execution context (will be instantiated by
   # the worker for each job execution)
   # @param submitter_class[Class] the class used for submitting jobs (will be instantiated by the worker for each job execution)
   # @param middleware_stack[Sqewer::MiddlewareStack] the middleware stack that is going to be used

--- a/lib/sqewer/worker.rb
+++ b/lib/sqewer/worker.rb
@@ -225,7 +225,7 @@ class Sqewer::Worker
       logger.debug { "[worker] Flushed %d connection commands" % n_flushed }
     end
 
-    dt = Process.clock_gettime(Process::CLOCK_MONOTONIC) - t
+    delta = Process.clock_gettime(Process::CLOCK_MONOTONIC) - t
     logger.info { "[worker] Finished %s in %0.2fs" % [job.inspect, delta] }
   end
 

--- a/spec/sqewer/submitter_spec.rb
+++ b/spec/sqewer/submitter_spec.rb
@@ -4,13 +4,13 @@ describe Sqewer::Submitter do
   describe '.default' do
     it 'returns a set up Submitter with the configured Connection and Serializer' do
       expect(ENV).to receive(:fetch).with('SQS_QUEUE_URL').and_return('https://some-queue.aws.com')
-      
+
       s = described_class.default
       expect(s.connection).to respond_to(:send_message)
       expect(s.serializer).to respond_to(:serialize)
     end
   end
-  
+
   describe '#initialize' do
     it 'creates a Submitter that you can submit jobs through' do
       fake_serializer = double('Some serializer')
@@ -18,61 +18,79 @@ describe Sqewer::Submitter do
         expect(object_to_serialize).not_to be_nil
         'serialized-object-data'
       }
-      
+
       fake_connection = double('Some SQS connection')
       expect(fake_connection).to receive(:send_message).at_least(5).times.with('serialized-object-data', any_args)
 
       fake_job = double('Some job', run: true)
-      
+
       subject = described_class.new(fake_connection, fake_serializer)
       5.times { subject.submit!(fake_job) }
     end
-    
+
     it 'passes the keyword arguments to send_message on the connection' do
       fake_serializer = double('Some serializer')
       allow(fake_serializer).to receive(:serialize) {|object_to_serialize|
         expect(object_to_serialize).not_to be_nil
         'serialized-object-data'
       }
-      
+
       fake_connection = double('Some SQS connection')
       expect(fake_connection).to receive(:send_message).with('serialized-object-data', {delay_seconds: 5})
 
       fake_job = double('Some job', run: true)
-      
+
       subject = described_class.new(fake_connection, fake_serializer)
       subject.submit!(fake_job, delay_seconds: 5)
     end
-    
+
     it 'handles the massively delayed execution by clamping the delay_seconds to the SQS maximum, and saving the _execute_after' do
       fake_serializer = double('Some serializer')
       allow(fake_serializer).to receive(:serialize) {|object_to_serialize, timestamp_seconds|
-        
+
         delay_by = Time.now.to_i + 4585659855
         expect(timestamp_seconds).to be_within(20).of(delay_by)
-        
+
         expect(object_to_serialize).not_to be_nil
         'serialized-object-data'
       }
-      
+
       fake_connection = double('Some SQS connection')
       expect(fake_connection).to receive(:send_message).with('serialized-object-data', {delay_seconds: 899})
 
       fake_job = double('Some job', run: true)
-      
+
       subject = described_class.new(fake_connection, fake_serializer)
       subject.submit!(fake_job, delay_seconds: 4585659855)
     end
 
-    it "raises an error if the job does not respond to call" do
+    it "raises an error if the job does not respond to #run" do
       fake_serializer = double('Some serializer')
       fake_connection = double('Some SQS connection')
       fake_job = double('Some job')
-      
+
       subject = described_class.new(fake_connection, fake_serializer)
       expect {
         subject.submit!(fake_job, delay_seconds: 5)
       }.to raise_error(Sqewer::Submitter::NotSqewerJob)
+    end
+
+    it "raises an error if the job produces a message above the SQS size limit" do
+      class VeryLargeTestJob < Struct.new(:some_data)
+        def run
+        end
+      end
+
+      large_blob = Base64.strict_encode64(Random.new.bytes(257*1024))
+      large_job = VeryLargeTestJob.new(large_blob)
+
+      fake_serializer = Sqewer::Serializer.default
+      fake_connection = double('Some SQS connection')
+
+      subject = described_class.new(fake_connection, fake_serializer)
+      expect {
+        subject.submit!(large_job)
+      }.to raise_error(Sqewer::Submitter::MessageTooLarge, /VeryLargeTestJob/)
     end
   end
 end


### PR DESCRIPTION
There was a subtle failure mode where an oversize message sent to SQS would generate an exception, but this would happen outside of the middleware blocks (thus avoiding error tracking which the middleware might provide). There were also no message size checks in the `submit!` methods, meaning that the error would be deferred to the moment the actual submit to the queue would be attempted - instead of raising immediately when the job gets passed to the Sqewer modules from a job.

This PR will ensure that:
* Both cleanup (message delete and delivery of generated messages) for a job are within the middleware blocks
* Messages are verified for size on spool, not on delivery to SQS (and by us and not by the AWS SDK)