### PR TITLE
Enable stdout sync to flush the logs

### DIFF
--- a/lib/sqewer/cli.rb
+++ b/lib/sqewer/cli.rb
@@ -1,3 +1,4 @@
+$stdout.sync = true
 # Wraps a Worker object in a process-wide commanline handler. Once the `start` method is
 # called, signal handlers will be installed for the following signals:
 #


### PR DESCRIPTION
closes #63 

Adds `$stdout.sync = true` to Cli