### PR TITLE
Add support for using sqlite in memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,20 @@ it will not be free. We think that this is an acceptable workaround for now, tho
 you may be better off using a Rails scheduling system and use a cron job or similar to spin up your enqueue
 for the actual, executable background task.
 
+# Testing
+
+It's possible to use Sqlite to emulate SQS when running the tests.
+
+To do so, change the value of the env SQS_QUEUE_URL as the following examples:
+
+```
+# to use a file
+SQS_QUEUE_URL=sqlite:/path/filename.sqlite3
+
+# to use the memory
+SQS_QUEUE_URL=sqlite:/memory
+```
+
 # Frequently asked questions (A.K.A. _why is it done this way_)
 
 This document tries to answer some questions that may arise when reading or using the library. Hopefully

--- a/README.md
+++ b/README.md
@@ -355,8 +355,7 @@ To do so, change the value of the env SQS_QUEUE_URL as the following examples:
 
 ```
 # to use a file
-SQS_QUEUE_URL=sqlite3://path/filename.sqlite3
-# note: the path is absolute, in this case /path
+SQS_QUEUE_URL=sqlite3://absolute_path/filename.sqlite3
 
 # to use the memory
 SQS_QUEUE_URL=sqlite3:memory

--- a/README.md
+++ b/README.md
@@ -355,10 +355,11 @@ To do so, change the value of the env SQS_QUEUE_URL as the following examples:
 
 ```
 # to use a file
-SQS_QUEUE_URL=sqlite3:/path/filename.sqlite3
+SQS_QUEUE_URL=sqlite3://path/filename.sqlite3
+# note: the path is absolute, in this case /path
 
 # to use the memory
-SQS_QUEUE_URL=sqlite3:/memory
+SQS_QUEUE_URL=sqlite3://memory
 ```
 
 # Frequently asked questions (A.K.A. _why is it done this way_)

--- a/README.md
+++ b/README.md
@@ -354,15 +354,10 @@ It's possible to use SQLite to emulate SQS when running the tests.
 To do so, change the value of the env SQS_QUEUE_URL as the following examples:
 
 ```
-# To use a file
-
-# It saves the data in /tmp/filename.sqlite3)
-SQS_QUEUE_URL=sqlite3://tmp/filename.sqlite3
-
-# It saves the data in /var/tmp/filename.sqlite3)
+# It saves the data in /var/tmp/filename.sqlite3
 SQS_QUEUE_URL=sqlite3://var/tmp/filename.sqlite3
 
-# To use the memory
+# It saves the data in memory
 SQS_QUEUE_URL=sqlite3:memory
 ```
 

--- a/README.md
+++ b/README.md
@@ -349,15 +349,20 @@ for the actual, executable background task.
 
 # Testing
 
-It's possible to use Sqlite to emulate SQS when running the tests.
+It's possible to use SQLite to emulate SQS when running the tests.
 
 To do so, change the value of the env SQS_QUEUE_URL as the following examples:
 
 ```
-# to use a file
-SQS_QUEUE_URL=sqlite3://absolute_path/filename.sqlite3
+# To use a file
 
-# to use the memory
+# It saves the data in /tmp/filename.sqlite3)
+SQS_QUEUE_URL=sqlite3://tmp/filename.sqlite3
+
+# It saves the data in /var/tmp/filename.sqlite3)
+SQS_QUEUE_URL=sqlite3://var/tmp/filename.sqlite3
+
+# To use the memory
 SQS_QUEUE_URL=sqlite3:memory
 ```
 

--- a/README.md
+++ b/README.md
@@ -355,10 +355,10 @@ To do so, change the value of the env SQS_QUEUE_URL as the following examples:
 
 ```
 # to use a file
-SQS_QUEUE_URL=sqlite:/path/filename.sqlite3
+SQS_QUEUE_URL=sqlite3:/path/filename.sqlite3
 
 # to use the memory
-SQS_QUEUE_URL=sqlite:/memory
+SQS_QUEUE_URL=sqlite3:/memory
 ```
 
 # Frequently asked questions (A.K.A. _why is it done this way_)

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ SQS_QUEUE_URL=sqlite3://path/filename.sqlite3
 # note: the path is absolute, in this case /path
 
 # to use the memory
-SQS_QUEUE_URL=sqlite3://memory
+SQS_QUEUE_URL=sqlite3:memory
 ```
 
 # Frequently asked questions (A.K.A. _why is it done this way_)

--- a/lib/sqewer/local_connection.rb
+++ b/lib/sqewer/local_connection.rb
@@ -3,14 +3,14 @@ class Sqewer::LocalConnection < Sqewer::Connection
   ASSUME_DEADLETTER_AFTER_N_DELIVERIES = 10
 
   def self.parse_queue_url(queue_url_starting_with_sqlite3_proto)
+    if queue_url_starting_with_sqlite3_proto == 'sqlite3:memory'
+      return ['memory', nil]
+    end
+
     uri = URI.parse(queue_url_starting_with_sqlite3_proto)
 
     unless uri.scheme == 'sqlite3'
       raise "The scheme of the SQS queue URL should be with `sqlite3' but was %s" % uri.scheme
-    end
-
-    if uri.hostname == 'memory'
-      return ['memory', nil]
     end
 
     path_components = ['/', uri.hostname, uri.path].reject(&:nil?).reject(&:empty?).join('/').squeeze('/')

--- a/lib/sqewer/local_connection.rb
+++ b/lib/sqewer/local_connection.rb
@@ -25,7 +25,13 @@ class Sqewer::LocalConnection < Sqewer::Connection
   #
   # Examples:
   #
-  #   LocalConnection.new('sqlite3://absolute_path/filename.sqlite3')
+  #   # To save the data in /tmp/filename.sqlite3
+  #   LocalConnection.new('sqlite3://tmp/filename.sqlite3')
+  #
+  #   # To save the data in /var/tmp/filename.sqlite3
+  #   LocalConnection.new('sqlite3://var/tmp/filename.sqlite3')
+  #
+  #   # To save the data in memory
   #   LocalConnection.new('sqlite3:memory')
   #
   # Note: When using the memory, it's not possible to create more than 1 queue

--- a/lib/sqewer/local_connection.rb
+++ b/lib/sqewer/local_connection.rb
@@ -4,7 +4,7 @@ class Sqewer::LocalConnection < Sqewer::Connection
 
   def self.parse_queue_url(queue_url_starting_with_sqlite3_proto)
     if queue_url_starting_with_sqlite3_proto == 'sqlite3:memory'
-      return ['memory', nil]
+      return [':memory:', nil]
     end
 
     uri = URI.parse(queue_url_starting_with_sqlite3_proto)
@@ -87,8 +87,8 @@ class Sqewer::LocalConnection < Sqewer::Connection
   private
 
   def with_db(**k)
-    if @db_path == 'memory'
-      @db_connection ||= SQLite3::Database.new(':memory:')
+    if @db_path == ':memory:'
+      @db_connection ||= SQLite3::Database.new(@db_path)
       return yield @db_connection
     else
       SQLite3::Database.open(@db_path, **k) do |db|

--- a/lib/sqewer/local_connection.rb
+++ b/lib/sqewer/local_connection.rb
@@ -25,9 +25,6 @@ class Sqewer::LocalConnection < Sqewer::Connection
   #
   # Examples:
   #
-  #   # To save the data in /tmp/filename.sqlite3
-  #   LocalConnection.new('sqlite3://tmp/filename.sqlite3')
-  #
   #   # To save the data in /var/tmp/filename.sqlite3
   #   LocalConnection.new('sqlite3://var/tmp/filename.sqlite3')
   #

--- a/lib/sqewer/local_connection.rb
+++ b/lib/sqewer/local_connection.rb
@@ -25,8 +25,8 @@ class Sqewer::LocalConnection < Sqewer::Connection
   #
   # Examples:
   #
-  #   LocalConnection.new('sqlite3:/path/filename.sqlite3')
-  #   LocalConnection.new('sqlite3:/memory')
+  #   LocalConnection.new('sqlite3://absolute_path/filename.sqlite3')
+  #   LocalConnection.new('sqlite3:memory')
   #
   # Note: When using the memory, it's not possible to create more than 1 queue
   def initialize(queue_url_with_sqlite3_scheme)

--- a/spec/sqewer/local_connection_spec.rb
+++ b/spec/sqewer/local_connection_spec.rb
@@ -89,7 +89,7 @@ describe Sqewer::LocalConnection do
   end
 
   it 'allows using an in memory database' do
-    conn = described_class.new('sqlite3://memory')
+    conn = described_class.new('sqlite3:memory')
 
     conn.send_message("Hello 1")
     conn.send_message("Hello 2")

--- a/spec/sqewer/local_connection_spec.rb
+++ b/spec/sqewer/local_connection_spec.rb
@@ -89,7 +89,7 @@ describe Sqewer::LocalConnection do
   end
 
   it 'allows using an in memory database' do
-    conn = described_class.new('sqlite3:/memory')
+    conn = described_class.new('sqlite3://memory')
 
     conn.send_message("Hello 1")
     conn.send_message("Hello 2")

--- a/spec/sqewer/local_connection_spec.rb
+++ b/spec/sqewer/local_connection_spec.rb
@@ -89,7 +89,7 @@ describe Sqewer::LocalConnection do
   end
 
   it 'allows using an in memory database' do
-    conn = described_class.new('sqlite3://memory')
+    conn = described_class.new('sqlite3:/memory')
 
     conn.send_message("Hello 1")
     conn.send_message("Hello 2")

--- a/spec/sqewer/local_connection_spec.rb
+++ b/spec/sqewer/local_connection_spec.rb
@@ -87,4 +87,14 @@ describe Sqewer::LocalConnection do
     Process.wait(consumer_pid)
     expect($?.exitstatus).to eq(0)
   end
+
+  it 'allows using an in memory database' do
+    conn = described_class.new('sqlite3://memory')
+
+    conn.send_message("Hello 1")
+    conn.send_message("Hello 2")
+
+    messages = conn.receive_messages
+    expect(messages.map(&:body)).to eq(["Hello 1", "Hello 2"])
+  end
 end


### PR DESCRIPTION
closes https://github.com/WeTransfer/sqewer/issues/61

This PR adds an option to use SQLite in memory when running the tests.

This helps when running the tests inside a container which does not have sqlite3 installed on it.