### PR TITLE
Also retry on Aws::SQS::Errors::InternalError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 6.5.1
+- Also retry on `Aws::SQS::Errors::InternalError` exception when receiving/sending messages. This will make
+  the receiving thread more resilient to sudden SQS failures. By the time SQS recovers the receiving thread
+  should stay alive.
+
 ### 6.5.0
 - Adds `$stdout.sync = true` to CLI to flush the logs to STDOUT
 

--- a/lib/sqewer/version.rb
+++ b/lib/sqewer/version.rb
@@ -1,3 +1,3 @@
 module Sqewer
-  VERSION = '6.5.0'
+  VERSION = '6.5.1'
 end


### PR DESCRIPTION
Apparently our receiver can die if this happens, and previously we would not rescue it. This leaves the Sqewer worker in an invalid state, where the receiving thread is dead but the worker threads keep churning. While the worker process will terminate in this situation it is still much cheaper to make this retriable instead.