### PR TITLE
Add option to inject SQS client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,7 @@
 gemfile:
-  - gemfiles/Gemfile.rails-4.2.x
   - gemfiles/Gemfile.rails-5.0.x
   - gemfiles/Gemfile.rails-5.1.x
 rvm:
-  - 2.3.7
-  - 2.4.5
-  - 2.5.1
   - 2.6.5
   - 2.7.0
 cache: bundler
@@ -13,15 +9,3 @@ sudo: false
 env:
   global:
   - AWS_REGION=eu-central-1
-matrix:
-  exclude:
-  - rvm: 2.3.7
-    gemfile: gemfiles/Gemfile.rails-5.0.x
-  - rvm: 2.3.7
-    gemfile: gemfiles/Gemfile.rails-5.1.x
-  - rvm: 2.5.1
-    gemfile: gemfiles/Gemfile.rails-4.2.x
-  - rvm: 2.6.5
-    gemfile: gemfiles/Gemfile.rails-4.2.x
-  - rvm: 2.7.0
-    gemfile: gemfiles/Gemfile.rails-4.2.x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 6.6.0
+- Change `Sqewer::Connection` to preferentially use a singleton instance of `Aws::SQS::Client`, which can be set using `Sqewer.client=`. This avoids many HTTP requests to the AWS metadata endpoint when getting credentials.
+
 ### 6.5.1
 - Also retry on `Aws::SQS::Errors::InternalError` exception when receiving/sending messages. This will make
   the receiving thread more resilient to sudden SQS failures. By the time SQS recovers the receiving thread

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-### 6.6.0
+### 7.0.0
+- Remove support of Ruby 2.3, 2.4 and 2.5
+- Remove support of Rails 4
 - Change `Sqewer::Connection` to preferentially use a singleton instance of `Aws::SQS::Client`, which can be set using `Sqewer.client=`. This avoids many HTTP requests to the AWS metadata endpoint when getting credentials.
 
 ### 6.5.1

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The messages will only be deleted from SQS once the job execution completes with
 
 ## Requirements
 
-Ruby 2.1+, version 2 of the AWS SDK. You can also run Sqewer backed by a SQLite database file, which can be handy for development situations.
+Ruby 2.6+, version 2 of the AWS SDK. You can also run Sqewer backed by a SQLite database file, which can be handy for development situations.
 
 ## Job storage
 
@@ -288,7 +288,7 @@ and traceable (make good use of logging).
 
 # Usage with Rails via ActiveJob
 
-This gem includes a queue adapter for usage with ActiveJob in Rails 4.2+. The functionality
+This gem includes a queue adapter for usage with ActiveJob in Rails 5+. The functionality
 is well-tested and should function for any well-conforming ActiveJob subclasses.
 
 To run the default `sqewer` worker setup against your Rails application, first set it as the

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "bundler/setup"
+require "sqewer"
+
+require "irb"
+IRB.start(__FILE__)

--- a/gemfiles/Gemfile.rails-4.2.x
+++ b/gemfiles/Gemfile.rails-4.2.x
@@ -1,8 +1,0 @@
-source "http://rubygems.org"
-
-# Gemspec as base dependency set
-gemspec path: __dir__ + '/..'
-
-gem 'sqlite3', '~> 1.3.6'
-gem 'activejob', "~> 4.2.0"
-gem 'activerecord', "~> 4.2.0"

--- a/lib/sqewer.rb
+++ b/lib/sqewer.rb
@@ -11,6 +11,25 @@ module Sqewer
     end
   end
 
+  # Sets an instance of Aws::SQS::Client to be used as a singleton.
+  # We recommend setting the options instance_profile_credentials_timeout and
+  # instance_profile_credentials_retries, for example:
+  #
+  #   sqs_client = Aws::SQS::Client.new(
+  #     instance_profile_credentials_timeout: 1,
+  #     instance_profile_credentials_retries: 5,
+  #   )
+  #   Storm.client = sqs_client
+  #
+  # @param client[Aws::SQS::Client] an instance of Aws::SQS::Client
+  def self.client=(client)
+    @client = client
+  end
+
+  def self.client
+    @client
+  end
+
   # Loads a particular Sqewer extension that is not loaded
   # automatically during the gem require.
   #

--- a/lib/sqewer/connection.rb
+++ b/lib/sqewer/connection.rb
@@ -214,7 +214,9 @@ class Sqewer::Connection
     # It's better using a singleton client to prevent making a lot of HTTP
     # requests to the AWS metadata endpoint when getting credentials.
     # Maybe in the future, we can remove @client and use Storm.client only.
-    Sqewer.client || @client ||= Aws::SQS::Client.new(
+    return Sqewer.client if Sqewer.client
+
+    @client ||= Aws::SQS::Client.new(
       instance_profile_credentials_timeout: 1, # defaults to 1 second
       instance_profile_credentials_retries: 5, # defaults to 0 retries
     )

--- a/lib/sqewer/connection.rb
+++ b/lib/sqewer/connection.rb
@@ -211,7 +211,10 @@ class Sqewer::Connection
   end
 
   def client
-    @client ||= Aws::SQS::Client.new(
+    # It's better using a singleton client to prevent making a lot of HTTP
+    # requests to the AWS metadata endpoint when getting credentials.
+    # Maybe in the future, we can remove @client and use Storm.client only.
+    Sqewer.client || @client ||= Aws::SQS::Client.new(
       instance_profile_credentials_timeout: 1, # defaults to 1 second
       instance_profile_credentials_retries: 5, # defaults to 0 retries
     )

--- a/sqewer.gemspec
+++ b/sqewer.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = %q{Process jobs from SQS}
   spec.description   = %q{A full-featured library for all them SQS worker needs}
   spec.homepage      = "https://github.com/WeTransfer/sqewer"
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.6.0")
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the "allowed_push_host"
   # to allow pushing to a single host or delete this section to allow pushing to any host.


### PR DESCRIPTION
related to https://github.com/WeTransfer/wt_s3_signer/pull/12

## Motivation

Every time that we call `Sqewer.submit!`, it creates a new instance of `Aws::SQS::Client` internally.

With that, AWS credentials are not cached when using `Aws::InstanceProfileCredentials`. 

So, every time it is necessary to get new credentials, which makes 3 HTTP requests to the AWS metadata endpoint.

## Proposal

This PR changes the method `Sqewer::Connection#client` to preferentially use a singleton instance of `Aws::SQS::Client`, which can be set using `Sqewer.client=`

## Comment

In the future, after testing this approach in production, we can create the `sqs_client` instance internally by default, with no needs to be injected via `Storm.client=`