### PR TITLE
Change Sqewer::Connection to use a singleton SQS client by default

### DIFF
--- a/lib/sqewer.rb
+++ b/lib/sqewer.rb
@@ -11,23 +11,9 @@ module Sqewer
     end
   end
 
-  # Sets an instance of Aws::SQS::Client to be used as a singleton.
-  # We recommend setting the options instance_profile_credentials_timeout and
-  # instance_profile_credentials_retries, for example:
-  #
-  #   sqs_client = Aws::SQS::Client.new(
-  #     instance_profile_credentials_timeout: 1,
-  #     instance_profile_credentials_retries: 5,
-  #   )
-  #   Storm.client = sqs_client
-  #
-  # @param client[Aws::SQS::Client] an instance of Aws::SQS::Client
-  def self.client=(client)
-    @client = client
-  end
-
+  # Returns a singleton of Aws::SQS::Client
   def self.client
-    @client
+    Sqewer::Connection.client
   end
 
   # Loads a particular Sqewer extension that is not loaded

--- a/lib/sqewer/connection.rb
+++ b/lib/sqewer/connection.rb
@@ -43,7 +43,6 @@ class Sqewer::Connection
   def self.client
     # It's better using a singleton client to prevent making a lot of HTTP
     # requests to the AWS metadata endpoint when getting credentials.
-    # Maybe in the future, we can remove @client and use Storm.client only.
     @client ||= begin
       require 'aws-sdk-sqs'
       ::Aws::SQS::Client.new(


### PR DESCRIPTION
related to https://github.com/WeTransfer/sqewer/pull/74

To prevent making lots of requests to the AWS metadata endpoint to get credentials, this PR changes `Sqewer::Connection` to use a singleton SQS client by default.

More details on this blog post: https://ideas.bywetransfer.com/story/spelunking-ruby-gems