### PR TITLE
Release the singleton SQS client when AWS raises a credential error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 8.0.1
+- Release the singleton SQS client when AWS raises credentials error to be able to use a new credential next time
+
 ### 8.0.0
 - Remove method `Sqewer.client=`
 - Change `Sqewer::Connection` to use a singleton SQS client by default

--- a/lib/sqewer/version.rb
+++ b/lib/sqewer/version.rb
@@ -1,3 +1,3 @@
 module Sqewer
-  VERSION = '8.0.0'
+  VERSION = '8.0.1'
 end

--- a/spec/sqewer/connection_spec.rb
+++ b/spec/sqewer/connection_spec.rb
@@ -135,8 +135,6 @@ describe Sqewer::Connection do
         :send_message_batch,
         Aws::Errors::MissingCredentialsError.new(_context = nil, _message = nil)
       )
-      # expect(fake_sqs_client).to receive(:send_message_batch)
-      #   .and_raise(Aws::Errors::MissingCredentialsError.new(_context = nil, _message = nil))
 
       conn = described_class.new('https://fake-queue.com', client: fake_sqs_client)
       expect do

--- a/sqewer.gemspec
+++ b/sqewer.gemspec
@@ -50,4 +50,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "dotenv"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "appsignal", '~> 2'
+  spec.add_development_dependency "pry-byebug"
 end


### PR DESCRIPTION
We noticed cases where errors related to AWS credentials started to happen suddenly.

We don't know the root cause yet, but what we can do is release the singleton `@client` instance because it contains a cache of credentials that in most cases is no longer valid.