### PR TITLE
Add `Aws::SQS::Errors::AccessDenied` to the list of errors that Sqewer must release SQS client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 8.0.2
+- Add `Aws::SQS::Errors::AccessDenied` to the list of errors that Sqewer must release the singleton SQS client
+
 ### 8.0.1
 - Release the singleton SQS client when AWS raises credentials error to be able to use a new credential next time
 

--- a/lib/sqewer/version.rb
+++ b/lib/sqewer/version.rb
@@ -1,3 +1,3 @@
 module Sqewer
-  VERSION = '8.0.1'
+  VERSION = '8.0.2'
 end


### PR DESCRIPTION
We noticed another error that Sqewer must release the singleton SQS client

Actually, there is a risk to be necessary to add more classes to the list, but I don't know if it would better to change the approach and consider any error from AWS, wdyt?