### PR TITLE
Fix Sqewer::Connection to properly get the list of AWS errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ Gemfile.lock
 
 # Used by RuboCop. Remote config files pulled in from inherit_from directive.
 # .rubocop-https?--*
+
+workdb.sqlite3*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 8.0.3
+- Fix `Sqewer::Connection` to properly get the list of AWS errors
+
 ### 8.0.2
 - Add `Aws::SQS::Errors::AccessDenied` to the list of errors that Sqewer must release the singleton SQS client
 

--- a/lib/sqewer/connection.rb
+++ b/lib/sqewer/connection.rb
@@ -245,9 +245,6 @@ class Sqewer::Connection
     raise
   end
 
-  # We tried to define this list using a constant in the class, but it's not
-  # possible because aws-sqs-sdk is loaded only during runtime, when
-  # SQS_QUEUE_URL doesn't use Sqlite
   def sqs_errors_to_release_client
     [
       Aws::Errors::MissingCredentialsError,

--- a/lib/sqewer/version.rb
+++ b/lib/sqewer/version.rb
@@ -1,3 +1,3 @@
 module Sqewer
-  VERSION = '8.0.2'
+  VERSION = '8.0.3'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,6 @@ $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require 'rspec'
 require 'rspec/wait'
 require 'dotenv'
-require 'aws-sdk-sqs'
 require 'simplecov'
 require 'securerandom'
 Dotenv.load

--- a/spec/sqewer/connection_spec.rb
+++ b/spec/sqewer/connection_spec.rb
@@ -125,14 +125,17 @@ describe Sqewer::Connection do
     it 'retries on networking errors'
 
     [
-      Aws::Errors::MissingCredentialsError,
-      Aws::SQS::Errors::AccessDenied,
-    ].each do |error_class|
-      it "releases the sqs singleton client when AWS raises #{error_class}" do
+      'Aws::Errors::MissingCredentialsError',
+      'Aws::SQS::Errors::AccessDenied',
+    ].each do |error_class_name|
+      it "releases the sqs singleton client when AWS raises #{error_class_name}" do
         # We just want to assign the singleton client to test that it was released
         # in the end
         old_client = described_class.client
         expect(old_client).not_to be_nil
+
+        # aws-sdk-sqs is loaded only after the method `.client`
+        error_class = Object.const_get(error_class_name)
 
         fake_sqs_client = Aws::SQS::Client.new(stub_responses: true)
         fake_sqs_client.stub_responses(
@@ -231,14 +234,17 @@ describe Sqewer::Connection do
     it 'retries on networking errors'
 
     [
-      Aws::Errors::MissingCredentialsError,
-      Aws::SQS::Errors::AccessDenied,
-    ].each do |error_class|
-      it "releases the sqs singleton client when AWS raises #{error_class}" do
+      'Aws::Errors::MissingCredentialsError',
+      'Aws::SQS::Errors::AccessDenied',
+    ].each do |error_class_name|
+      it "releases the sqs singleton client when AWS raises #{error_class_name}" do
         # We just want to assign the singleton client to test that it was released
         # in the end
         old_client = described_class.client
         expect(old_client).not_to be_nil
+
+        # aws-sdk-sqs is loaded only after the method `.client`
+        error_class = Object.const_get(error_class_name)
 
         fake_sqs_client = Aws::SQS::Client.new(stub_responses: true)
         fake_sqs_client.stub_responses(


### PR DESCRIPTION
## Motivation

Version 8.0.2 broke tests in the applications with `uninitialized constant Sqewer::Connection::Aws`.

This happens because the `aws-sdk-sqs` gem is not required by Sqewer.

(There is a logic to not load `aws-sdk-sqs` from the beginning because it's possible to use Sqlite as the queue)

However, it was required by tests, in `spec_helper`.

Because of this, the tests didn't break here.

## Proposal

This PR:
- removes `require aws-sdk-sqs` from spec_helper to be possible to simulate the issue mentioned above
- fixes `Sqewer::Connection` to load AWS error classes using a method, and not a constant