### PR TITLE
fix: ensure the worker exits when a thread dies with an unhandled exception

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
     - name: install gems
       run: |
-        gem install sqlite3
+        gem install sqlite3 -v '~> 1.0'
         gem install bundler
         bundle install --gemfile ${{ matrix.gemfile }}
     - name: Tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 10.0.0
+- Ensure all worker threads exit if a thread dies in case of an unhandled exception, to avoid "zombie" workers (running without any consumer thread)
+
 ### 9.0.0
 - Add support for Ruby 3.2 and Rails 7
 - Remove support for Ruby 2.6, 2.7 and Rails 5 and 6.0

--- a/lib/sqewer/version.rb
+++ b/lib/sqewer/version.rb
@@ -1,3 +1,3 @@
 module Sqewer
-  VERSION = '9.0.0'
+  VERSION = '10.0.0'
 end

--- a/lib/sqewer/worker.rb
+++ b/lib/sqewer/worker.rb
@@ -93,8 +93,10 @@ class Sqewer::Worker
     # to avoid silent failures with no consumer threads running.
     Thread.abort_on_exception = true
 
-    consumers = (1..@num_threads).map do
+    consumers = (1..@num_threads).each_with_index.map do |_, index|
       Thread.new do
+        Thread.current[:role] = :consumer
+        Thread.current[:id] = index
         loop { take_and_execute }
       end
     end
@@ -103,6 +105,7 @@ class Sqewer::Worker
     # grab new messages and place them on the local queue.
     owning_worker = self # self won't be self anymore in the thread
     provider = Thread.new do
+      Thread.current[:role] = :provider
       loop do
         begin
           break if stopping?

--- a/lib/sqewer/worker.rb
+++ b/lib/sqewer/worker.rb
@@ -89,6 +89,10 @@ class Sqewer::Worker
     @logger.info { '[worker] Starting with %d consumer threads' % @num_threads }
     @execution_queue = Queue.new
 
+    # Ensure that unhandled exceptions inside threads make the worker fail,
+    # to avoid silent failures with no consumer threads running.
+    Thread.abort_on_exception = true
+
     consumers = (1..@num_threads).map do
       Thread.new do
         loop { take_and_execute }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 
+require 'base64'
 require 'rspec'
 require 'rspec/wait'
 require 'dotenv'


### PR DESCRIPTION
### Summary

We have evidence of workers using this library in which all threads died with some unhandled exceptions, and are just running with the `producer` thread, without any `consumer`.

This PR aims to ensure the whole worker exits when a thread dies with an unhandled exception, to avoid zombie workers.

### Data Points

- Stuck worker:
    ```
    PID USER      PR  NI    VIRT    RES    SHR S  %CPU  %MEM     TIME+ COMMAND                                                                                                                                                     
    19 wetrans+  20   0 1008384 280096  14768 S   0.0   0.4   1:29.12 worker.rb:101  
    ```

- Working worker:
    ```
    PID USER      PR  NI    VIRT    RES    SHR S  %CPU  %MEM     TIME+ COMMAND
    19 wetrans+  20   0  665408 193208  14556 S   1.0   0.6   0:04.56 worker.rb:101 
                                                                                  
    16 wetrans+  20   0  665408 192944  14556 S  21.9   0.6   3:10.02 worker.rb:93                                                                           
    17 wetrans+  20   0  665408 192944  14556 R  12.0   0.6   3:12.63 worker.rb:93                                                                           
    18 wetrans+  20   0  665408 192944  14556 S   7.0   0.6   2:59.62 worker.rb:93                                                                           
    ```